### PR TITLE
Store token

### DIFF
--- a/src/features/canvas/CanvasIntegration.ts
+++ b/src/features/canvas/CanvasIntegration.ts
@@ -2,10 +2,11 @@
 // Initialize Canvas polling
 const CANVAS_API = 'https://sit.instructure.com/api/v1/';
 function getUpcomingAssignments() {
-    chrome.storage.local.get('tokens', tokens => {
+    chrome.storage.local.get('tokens', object => {
         // If you want to test this, uncomment the code below with your token
         // tokens.canvas = '<YOUR TOKEN HERE>';
-        if (tokens.canvas !== '') {
+        let {tokens} = object;
+        if (tokens.canvas && tokens.canvas !== '') {
             const AUTH = '?access_token=' + tokens.canvas;
             fetch(CANVAS_API + 'users/self/upcoming_events' + AUTH)
                 .then(
@@ -21,7 +22,10 @@ function getUpcomingAssignments() {
                         .filter(x => x.type === 'assignment')
                         .map(x => {
                             // let due = moment(x.due).format('');
-                            return {title: x.title, due: x.assignment.due_at};
+                            return {
+                                title: x.title,
+                                due: x.assignment.due_at,
+                            };
                         });
                     chrome.storage.local.set({
                         upcomingAssignments: assignments,
@@ -43,4 +47,12 @@ chrome.runtime.onInstalled.addListener(details => {
             getUpcomingAssignments();
         }
     });
+});
+
+chrome.storage.onChanged.addListener(changes => {
+    for (let key in changes) {
+        if (key === 'tokens') {
+            getUpcomingAssignments();
+        }
+    }
 });

--- a/src/features/canvas/CanvasIntegration.ts
+++ b/src/features/canvas/CanvasIntegration.ts
@@ -3,8 +3,6 @@
 const CANVAS_API = 'https://sit.instructure.com/api/v1/';
 function getUpcomingAssignments() {
     chrome.storage.local.get('tokens', object => {
-        // If you want to test this, uncomment the code below with your token
-        // tokens.canvas = '<YOUR TOKEN HERE>';
         let {tokens} = object;
         if (tokens.canvas && tokens.canvas !== '') {
             const AUTH = '?access_token=' + tokens.canvas;

--- a/src/features/canvas/CanvasIntegration.ts
+++ b/src/features/canvas/CanvasIntegration.ts
@@ -2,9 +2,8 @@
 // Initialize Canvas polling
 const CANVAS_API = 'https://sit.instructure.com/api/v1/';
 function getUpcomingAssignments() {
-    chrome.storage.local.get('tokens', object => {
-        let {tokens} = object;
-        if (tokens.canvas && tokens.canvas !== '') {
+    chrome.storage.local.get('tokens', ({tokens}) => {
+        if (tokens.canvas) {
             const AUTH = '?access_token=' + tokens.canvas;
             fetch(CANVAS_API + 'users/self/upcoming_events' + AUTH)
                 .then(

--- a/src/options.pug
+++ b/src/options.pug
@@ -13,4 +13,20 @@ block append content
         input#room-availability(type='checkbox' name='features' checked)
         label(for='room-availability') Room Availability
     #tokens API Tokens
-        input#canvas-token(type='textbox')
+        h5 Canvas Token
+        p
+        | The Canvas token allows the web extension to access your Canvas, so it can
+        | show you useful information like your assignments. You must provide a Canvas
+        | token for Canvas Integration.
+        p
+        | To gain access to your Canvas token, navigate to
+        a(href="https://stevens.edu/canvas")  Canvas
+        |  and click on your
+        | profile. Click 'Settings' and scroll down until you see 'Approved Integrations.'
+        | Click the 'New Access Token' button and enter 'stevens-web-extension' in the
+        | textbox labeled 'Purpose'. Leave 'Expires' blank and generate the token. Copy
+        | this token and paste into the box below and submit it. You may also want to copy
+        | it somewhere else for safekeeping, as Canvas hides it after it first generates it.
+        p Note: DO NOT share your Canvas Token with anyone!
+        input#canvas-token(type='password' name='canvas' size=30 autocomplete='off'
+        placeholder='Canvas API Token')

--- a/src/options.pug
+++ b/src/options.pug
@@ -27,6 +27,6 @@ block append content
         | textbox labeled 'Purpose'. Leave 'Expires' blank and generate the token. Copy
         | this token and paste into the box below and submit it. You may also want to copy
         | it somewhere else for safekeeping, as Canvas hides it after it first generates it.
-        p Note: DO NOT share your Canvas Token with anyone!
-        input#canvas-token(type='password' name='canvas' size=30 autocomplete='off'
+        p Note: DO NOT share your Canvas token with anyone!
+        input#canvas-token(type='password' name='canvas' size=50 autocomplete='off'
         placeholder='Canvas API Token')

--- a/src/options.pug
+++ b/src/options.pug
@@ -29,4 +29,4 @@ block append content
         | it somewhere else for safekeeping, as Canvas hides it after it first generates it.
         p Note: DO NOT share your Canvas token with anyone!
         input#canvas-token(type='password' name='canvas' size=90 autocomplete='off'
-        placeholder='Canvas API Token')
+        placeholder='Canvas API Token' spellcheck=false)

--- a/src/options.pug
+++ b/src/options.pug
@@ -28,5 +28,5 @@ block append content
         | this token and paste into the box below and submit it. You may also want to copy
         | it somewhere else for safekeeping, as Canvas hides it after it first generates it.
         p Note: DO NOT share your Canvas token with anyone!
-        input#canvas-token(type='password' name='canvas' size=50 autocomplete='off'
+        input#canvas-token(type='password' name='canvas' size=90 autocomplete='off'
         placeholder='Canvas API Token')

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,9 @@
 let canvasTextbox: HTMLInputElement = document.querySelector(
     'input[name=canvas]'
 );
+let canvasCheckbox: HTMLInputElement = document.querySelector(
+    '#canvas-integration'
+);
 
 document.addEventListener('DOMContentLoaded', e => {
     let activeFeatures = {};
@@ -28,4 +31,18 @@ canvasTextbox.onfocus = () => {
 canvasTextbox.onblur = () => {
     canvasTextbox.setAttribute('type', 'password');
     chrome.storage.local.set({tokens: {canvas: canvasTextbox.value}});
+};
+
+//disable canvas API token text box when Canvas Integration
+//is not desired
+canvasCheckbox.onchange = () => {
+    if (canvasCheckbox.checked) {
+        canvasTextbox.readOnly = false;
+        canvasTextbox.style.backgroundColor = '#FFFFFF';
+        canvasTextbox.style.color = '#000000';
+        return;
+    }
+    canvasTextbox.style.backgroundColor = '#e3e3e3';
+    canvasTextbox.style.color = '#404040';
+    canvasTextbox.readOnly = true;
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -12,8 +12,8 @@ document.addEventListener('DOMContentLoaded', e => {
         .forEach((x: HTMLInputElement) => {
             activeFeatures[x.id] = x.checked;
         });
-    chrome.storage.local.get('tokens', object => {
-        canvasTextbox.value = object.tokens.canvas;
+    chrome.storage.local.get('tokens', ({tokens}) => {
+        canvasTextbox.value = tokens.canvas;
     });
     // log(activeFeatures);
     /* To Do

--- a/src/options.ts
+++ b/src/options.ts
@@ -24,5 +24,5 @@ canvasTextbox.onfocus = () => {
 
 canvasTextbox.onblur = () => {
     canvasTextbox.setAttribute('type', 'password');
-    chrome.storage.local.set({canvasAPIToken: canvasTextbox.value});
+    chrome.storage.local.set({tokens: {canvas: canvasTextbox.value}});
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,6 @@
-// import log from './shared/utility';
+let canvasTextbox: HTMLInputElement = document.querySelector(
+    'input[name=canvas]'
+);
 
 document.addEventListener('DOMContentLoaded', e => {
     let activeFeatures = {};
@@ -15,3 +17,12 @@ document.addEventListener('DOMContentLoaded', e => {
       chrome.storage.local.get('activeFeatures', result => { ... })
     */
 });
+
+canvasTextbox.onfocus = () => {
+    canvasTextbox.setAttribute('type', 'text');
+};
+
+canvasTextbox.onblur = () => {
+    canvasTextbox.setAttribute('type', 'password');
+    chrome.storage.local.set({canvasAPIToken: canvasTextbox.value});
+};

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,6 +9,9 @@ document.addEventListener('DOMContentLoaded', e => {
         .forEach((x: HTMLInputElement) => {
             activeFeatures[x.id] = x.checked;
         });
+    chrome.storage.local.get('tokens', object => {
+        canvasTextbox.value = object.tokens.canvas;
+    });
     // log(activeFeatures);
     /* To Do
     - Update the activeFeatures after someone (un)checks a feature


### PR DESCRIPTION
Closes #25 

The user can now input their Canvas API token into the textbox on the options page and it will save it to local storage. If the user does not wish to use the Canvas integration features, the textbox will not allow any further input, as it is not necessary. The input to this textbox is not shown unless the user is focused on it.

